### PR TITLE
RG-T132 Fixed Weather alerts info, fixed timezone issue

### DIFF
--- a/src/app/(app)/weather-alert-detail.tsx
+++ b/src/app/(app)/weather-alert-detail.tsx
@@ -109,15 +109,15 @@ export default function WeatherAlertDetailScreen() {
           <VStack space="xs">
             <HStack className="items-center justify-between">
               <Text className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>{t('weatherAlerts.detail.effective')}</Text>
-              <Text className={`text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{formatDateTime(alert.EffectiveUtc)}</Text>
+              <Text className={`text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{formatDateTime(alert.EffectiveOnUtc || alert.EffectiveUtc)}</Text>
             </HStack>
             <HStack className="items-center justify-between">
               <Text className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>{t('weatherAlerts.detail.onset')}</Text>
-              <Text className={`text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{formatDateTime(alert.OnsetUtc)}</Text>
+              <Text className={`text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{formatDateTime(alert.OnsetOnUtc || alert.OnsetUtc)}</Text>
             </HStack>
             <HStack className="items-center justify-between">
               <Text className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>{t('weatherAlerts.detail.expires')}</Text>
-              <Text className={`text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{formatDateTime(alert.ExpiresUtc)}</Text>
+              <Text className={`text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{formatDateTime(alert.ExpiresOnUtc || alert.ExpiresUtc)}</Text>
             </HStack>
           </VStack>
         </VStack>
@@ -168,10 +168,10 @@ export default function WeatherAlertDetailScreen() {
               <Text className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>{t('weatherAlerts.detail.certainty')}</Text>
               <Text className={`text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{t(CERTAINTY_KEYS[alert.Certainty] || 'weatherAlerts.certainty.unknown')}</Text>
             </HStack>
-            {alert.SenderName ? (
+            {alert.Sender ? (
               <HStack className="items-center justify-between">
                 <Text className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>{t('weatherAlerts.detail.sender')}</Text>
-                <Text className={`text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{alert.SenderName}</Text>
+                <Text className={`text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{alert.Sender}</Text>
               </HStack>
             ) : null}
           </VStack>

--- a/src/app/(app)/weather-alerts.tsx
+++ b/src/app/(app)/weather-alerts.tsx
@@ -76,17 +76,17 @@ export default function WeatherAlertsScreen() {
 
     switch (sort) {
       case 'expires':
-        result.sort((a, b) => new Date(a.ExpiresUtc).getTime() - new Date(b.ExpiresUtc).getTime());
+        result.sort((a, b) => new Date(a.ExpiresOnUtc || a.ExpiresUtc).getTime() - new Date(b.ExpiresOnUtc || b.ExpiresUtc).getTime());
         break;
       case 'newest':
-        result.sort((a, b) => new Date(b.EffectiveUtc).getTime() - new Date(a.EffectiveUtc).getTime());
+        result.sort((a, b) => new Date(b.EffectiveOnUtc || b.EffectiveUtc).getTime() - new Date(a.EffectiveOnUtc || a.EffectiveUtc).getTime());
         break;
       case 'severity':
       default:
         result.sort((a, b) => {
           // Core enum: Extreme=0 is most severe, so ascending puts the worst alerts first.
           if (a.Severity !== b.Severity) return a.Severity - b.Severity;
-          return new Date(b.EffectiveUtc).getTime() - new Date(a.EffectiveUtc).getTime();
+          return new Date(b.EffectiveOnUtc || b.EffectiveUtc).getTime() - new Date(a.EffectiveOnUtc || a.EffectiveUtc).getTime();
         });
         break;
     }
@@ -129,9 +129,9 @@ export default function WeatherAlertsScreen() {
             </Text>
             <HStack className="items-center justify-between">
               <Text className={`text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
-                {translate('weatherAlerts.detail.effective')}: {formatDateTime(item.EffectiveUtc)}
+                {translate('weatherAlerts.detail.effective')}: {formatDateTime(item.EffectiveOnUtc || item.EffectiveUtc)}
               </Text>
-              <Text className={`text-xs font-medium ${isDark ? 'text-amber-400' : 'text-amber-600'}`}>{formatExpiry(item.ExpiresUtc)}</Text>
+              <Text className={`text-xs font-medium ${isDark ? 'text-amber-400' : 'text-amber-600'}`}>{formatExpiry(item.ExpiresOnUtc || item.ExpiresUtc)}</Text>
             </HStack>
           </VStack>
         </HStack>

--- a/src/components/widgets/WeatherAlertsWidget.tsx
+++ b/src/components/widgets/WeatherAlertsWidget.tsx
@@ -112,7 +112,7 @@ const AlertCard: React.FC<AlertCardProps> = ({ alert, isDark, showHeadline, show
         ) : null}
         {showExpiry ? (
           <Text className={`${isDark ? 'text-gray-500' : 'text-gray-500'}`} style={{ fontSize: fontSize - 2 }}>
-            {formatExpiry(alert.ExpiresUtc)}
+            {formatExpiry(alert.ExpiresOnUtc || alert.ExpiresUtc)}
           </Text>
         ) : null}
       </VStack>

--- a/src/lib/__tests__/get-time-ago-utc.test.ts
+++ b/src/lib/__tests__/get-time-ago-utc.test.ts
@@ -1,0 +1,39 @@
+import { getTimeAgoUtc } from '../utils';
+
+describe('getTimeAgoUtc', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-19T20:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reads a Z-stamped UTC string without applying the legacy offset shift', () => {
+    expect(getTimeAgoUtc('2026-08-19T19:55:00.000Z')).toBe('5 minutes ago');
+  });
+
+  it('reads an offset-stamped string without applying the legacy offset shift', () => {
+    expect(getTimeAgoUtc('2026-08-19T12:55:00-07:00')).toBe('5 minutes ago');
+  });
+
+  it('still reads legacy zone-less UTC strings via the offset-shifted comparison', () => {
+    // Zone-less strings parse as device-local; the function compensates by shifting "now"
+    // by the same offset, so the result is correct in any device timezone.
+    const zoneless = new Date(Date.now() - 5 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, '');
+    expect(getTimeAgoUtc(zoneless)).toBe('5 minutes ago');
+  });
+
+  it('treats Date objects as exact instants', () => {
+    expect(getTimeAgoUtc(new Date(Date.now() - 5 * 60 * 1000))).toBe('5 minutes ago');
+  });
+
+  it('treats epoch milliseconds as exact instants', () => {
+    expect(getTimeAgoUtc(Date.now() - 5 * 60 * 1000)).toBe('5 minutes ago');
+  });
+
+  it('returns Unknown for empty input', () => {
+    expect(getTimeAgoUtc('')).toBe('Unknown');
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -431,18 +431,29 @@ export function getTimeAgoUtc(time: any): string {
     return 'Unknown';
   }
 
+  // Legacy API values are zone-less UTC strings that new Date() parses as device-local time;
+  // those need "now" shifted by the same offset below. Strings carrying an explicit Z/±hh:mm
+  // designator parse correctly and must not be shifted.
+  let hasZone = false;
+
   switch (typeof time) {
     case 'number':
+      // Epoch milliseconds are an exact instant — never shift.
+      hasZone = true;
       break;
     case 'string':
+      hasZone = /(Z|[+-]\d{2}:?\d{2})$/i.test(time.trim());
       time = +new Date(time);
       break;
     case 'object':
-      if (time.constructor === Date) {
+      if (time instanceof Date) {
+        // A Date is an exact instant — never shift.
+        hasZone = true;
         time = time.getTime();
       }
       break;
     default:
+      hasZone = true;
       time = +new Date();
   }
 
@@ -466,7 +477,8 @@ export function getTimeAgoUtc(time: any): string {
     [5806080000, 'Last century', 'Next century'], // 60*60*24*7*4*12*100*2
     [58060800000, 'centuries', 2903040000], // 60*60*24*7*4*12*100*20, 60*60*24*7*4*12*100
   ];
-  let seconds = (Number(new Date(currentDate).getTime() + new Date(currentDate).getTimezoneOffset() * 60 * 1000) - time) / 1000,
+  const nowMs = hasZone ? currentDate.getTime() : currentDate.getTime() + currentDate.getTimezoneOffset() * 60 * 1000;
+  let seconds = (nowMs - time) / 1000,
     token = 'ago',
     listChoice = 1;
 

--- a/src/models/v4/weatherAlerts/weatherAlertResultData.ts
+++ b/src/models/v4/weatherAlerts/weatherAlertResultData.ts
@@ -1,25 +1,37 @@
+// Mirrors Resgrid Core's v4 WeatherAlertResultData (Web/Resgrid.Web.Services/Models/v4/WeatherAlerts).
+// Enum-valued fields are ints (see WeatherAlertSeverity/Category/Urgency/Certainty/Status in Core).
 export class WeatherAlertResultData {
   public WeatherAlertId: string = '';
-  public DepartmentId: string = '';
+  public DepartmentId: number = 0;
+  public WeatherAlertSourceId: string = '';
+  public ExternalId: string = '';
+  public Sender: string = '';
   public Event: string = '';
-  public Severity: number = 0;
+  public AlertCategory: number = 4; // Other
+  public Severity: number = 4; // Unknown
+  public Urgency: number = 4; // Unknown
+  public Certainty: number = 4; // Unknown
+  public Status: number = 0; // Active
   public Headline: string = '';
   public Description: string = '';
   public Instruction: string = '';
   public AreaDescription: string = '';
   public Polygon: string = '';
+  public Geocodes: string = '';
   public CenterGeoLocation: string = '';
+  // Department-local display strings (despite the Utc names) — render verbatim only.
   public OnsetUtc: string = '';
   public ExpiresUtc: string = '';
   public EffectiveUtc: string = '';
-  public Status: number = 0;
-  public AlertCategory: number = 0;
-  public Urgency: number = 0;
-  public Certainty: number = 0;
-  public Sender: string = '';
-  public SenderName: string = '';
-  public SourceType: number = 0;
-  public ExternalId: string = '';
-  public References: string = '';
-  public Web: string = '';
+  public SentUtc: string = '';
+  public FirstSeenUtc: string = '';
+  public LastUpdatedUtc: string = '';
+  // Real UTC instants with explicit "Z" — use these for any date math. Empty on older servers.
+  public EffectiveOnUtc?: string = '';
+  public OnsetOnUtc?: string = '';
+  public ExpiresOnUtc?: string = '';
+  public SentOnUtc?: string = '';
+  public ReferencesExternalId: string = '';
+  public NotificationSent: boolean = false;
+  public SystemMessageId?: number;
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This PR fixes weather alert date/time handling and updates weather alert details to use the correct alert fields.

### What changed
- **Corrected weather alert date usage across the app**
  - Weather alert detail, list, and widget screens now prefer the newer UTC timestamp fields (`EffectiveOnUtc`, `OnsetOnUtc`, `ExpiresOnUtc`) when available.
  - Older fields are still used as a fallback for compatibility.

- **Fixed timezone-related “time ago” calculations**
  - Updated the shared UTC relative-time utility so it correctly handles:
    - UTC timestamps with `Z`
    - timestamps with explicit offsets
    - legacy zone-less UTC strings
    - `Date` objects and epoch values
  - This prevents incorrect offset shifting for timestamps that already include timezone information.

- **Updated weather alert sender display**
  - Weather alert detail now shows the sender from `Sender` instead of `SenderName`, matching the current data model.

- **Aligned the weather alert model with current API data**
  - Expanded the weather alert result model to include newer fields such as source identifiers, geocodes, sent/updated timestamps, notification-related fields, and the new explicit UTC timestamp fields.
  - Added defaults/comments that distinguish display-only date strings from true UTC values intended for date calculations.

### Functional impact
- Weather alerts should now display more accurate effective/onset/expiration times.
- Sorting and expiry calculations for alerts should behave correctly across timezones.
- Sender information in alert details now uses the correct field from the returned alert data.
- The app is better aligned with newer weather alert payloads while preserving fallback support for older servers.

### Validation
- Added unit tests covering the UTC “time ago” behavior for:
  - `Z`-based UTC timestamps
  - offset-based timestamps
  - legacy zone-less strings
  - `Date` instances
  - epoch milliseconds
  - empty input
<!-- kody-pr-summary:end -->