### PR TITLE
RG-T132 Buidl fix

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -298,7 +298,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     'expo-web-browser',
     './customGradle.plugin.js',
     './customManifest.plugin.js',
-    ['app-icon-badge', appIconBadgeConfig],
+    ['./appIconBadge.plugin.js', appIconBadgeConfig],
   ],
   extra: {
     ...ClientEnv,

--- a/appIconBadge.plugin.js
+++ b/appIconBadge.plugin.js
@@ -1,0 +1,101 @@
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Local replacement for the `app-icon-badge` config plugin.
+//
+// The upstream plugin swaps `icon` / `adaptiveIcon.foregroundImage` to
+// `.expo/app-icon-badge/*.png` but generates those files with a floating, error-swallowing
+// promise. `.expo/` is gitignored, so on a clean checkout (EAS) Expo's built-in icon mods
+// read the destination before Jimp has finished writing it - or before it exists at all -
+// which fails prebuild with:
+//   [android.dangerous]: withAndroidDangerousBaseMod: Could not find MIME for Buffer <null>
+//
+// Built-in mods are registered after user plugins and therefore run first, so generation
+// cannot be deferred to a mod. Instead it happens here, synchronously, while the config is
+// still being resolved, with the results cached so repeated config reads stay cheap.
+
+const DST_FOLDER = '.expo/app-icon-badge';
+const CACHE_FILE = `${DST_FOLDER}/.cache.json`;
+const DST_ICON = `${DST_FOLDER}/icon.png`;
+const DST_IOS_ICON = `${DST_FOLDER}/ios-icon.png`;
+const DST_ADAPTIVE_ICON = `${DST_FOLDER}/foregroundImage.png`;
+
+const fingerprint = (projectRoot, jobs) =>
+  JSON.stringify(
+    jobs.map((job) => {
+      const { size, mtimeMs } = fs.statSync(path.resolve(projectRoot, job.icon));
+      return { ...job, size, mtimeMs };
+    })
+  );
+
+const isUpToDate = (projectRoot, expected) => {
+  try {
+    const cache = fs.readFileSync(path.join(projectRoot, CACHE_FILE), 'utf8');
+    if (cache !== expected) return false;
+  } catch {
+    return false;
+  }
+
+  return [DST_ICON, DST_IOS_ICON, DST_ADAPTIVE_ICON].every((dst) => {
+    const file = path.join(projectRoot, dst);
+    return !fs.existsSync(file) || fs.statSync(file).size > 0;
+  });
+};
+
+const withAppIconBadge = (config, options = {}) => {
+  const { badges = [], enabled = true } = options;
+
+  if (!enabled || badges.length === 0) {
+    return config;
+  }
+
+  const projectRoot = config._internal?.projectRoot ?? process.cwd();
+  const jobs = [];
+
+  if (config.icon) {
+    jobs.push({ icon: config.icon, dstPath: DST_ICON, badges });
+    config.icon = DST_ICON;
+  }
+
+  if (config.android?.adaptiveIcon?.foregroundImage) {
+    jobs.push({
+      icon: config.android.adaptiveIcon.foregroundImage,
+      dstPath: DST_ADAPTIVE_ICON,
+      badges,
+      isAdaptiveIcon: true,
+    });
+    config.android.adaptiveIcon.foregroundImage = DST_ADAPTIVE_ICON;
+  }
+
+  if (config.ios?.icon) {
+    jobs.push({ icon: config.ios.icon, dstPath: DST_IOS_ICON, badges });
+    config.ios.icon = DST_IOS_ICON;
+  }
+
+  if (jobs.length === 0) {
+    return config;
+  }
+
+  const cacheKey = fingerprint(projectRoot, jobs);
+  if (isUpToDate(projectRoot, cacheKey)) {
+    return config;
+  }
+
+  const absoluteJobs = jobs.map((job) => ({
+    ...job,
+    icon: path.resolve(projectRoot, job.icon),
+    dstPath: path.join(projectRoot, job.dstPath),
+  }));
+
+  execFileSync(process.execPath, [path.join(projectRoot, 'scripts', 'generate-icon-badges.js'), JSON.stringify(absoluteJobs)], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
+
+  fs.writeFileSync(path.join(projectRoot, CACHE_FILE), cacheKey);
+
+  return config;
+};
+
+module.exports = withAppIconBadge;

--- a/patches/app-icon-badge+0.1.2.patch
+++ b/patches/app-icon-badge+0.1.2.patch
@@ -1,0 +1,39 @@
+diff --git a/node_modules/app-icon-badge/dist/app.plugin.js b/node_modules/app-icon-badge/dist/app.plugin.js
+index 76e16ff..70a392e 100644
+--- a/node_modules/app-icon-badge/dist/app.plugin.js
++++ b/node_modules/app-icon-badge/dist/app.plugin.js
+@@ -230,7 +230,7 @@ function addBadge(_0) {
+     const resultFilename = dstPath ? dstPath : getResultPath({
+       icon
+     });
+-    resultImage.writeAsync(resultFilename);
++    yield resultImage.writeAsync(resultFilename);
+     return resultFilename;
+   });
+ }
+diff --git a/node_modules/app-icon-badge/dist/index.js b/node_modules/app-icon-badge/dist/index.js
+index 3a05b92..47571ae 100644
+--- a/node_modules/app-icon-badge/dist/index.js
++++ b/node_modules/app-icon-badge/dist/index.js
+@@ -240,7 +240,7 @@ function addBadge(_0) {
+     const resultFilename = dstPath ? dstPath : getResultPath({
+       icon
+     });
+-    resultImage.writeAsync(resultFilename);
++    yield resultImage.writeAsync(resultFilename);
+     return resultFilename;
+   });
+ }
+diff --git a/node_modules/app-icon-badge/dist/index.mjs b/node_modules/app-icon-badge/dist/index.mjs
+index 201b24c..8c7562e 100644
+--- a/node_modules/app-icon-badge/dist/index.mjs
++++ b/node_modules/app-icon-badge/dist/index.mjs
+@@ -207,7 +207,7 @@ function addBadge(_0) {
+     const resultFilename = dstPath ? dstPath : getResultPath({
+       icon
+     });
+-    resultImage.writeAsync(resultFilename);
++    yield resultImage.writeAsync(resultFilename);
+     return resultFilename;
+   });
+ }

--- a/scripts/generate-icon-badges.js
+++ b/scripts/generate-icon-badges.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+// Generates the badged app icons used by ./appIconBadge.plugin.js.
+//
+// Runs as its own process so the plugin can block on it with execFileSync: Jimp is
+// async-only, but config resolution is synchronous and Expo's built-in icon mods read
+// the badged files before any user-registered mod gets a chance to run.
+
+const fs = require('fs');
+const path = require('path');
+const { addBadge } = require('app-icon-badge');
+
+const main = async () => {
+  const jobs = JSON.parse(process.argv[2]);
+
+  for (const job of jobs) {
+    fs.mkdirSync(path.dirname(job.dstPath), { recursive: true });
+    await addBadge(job);
+
+    const { size } = fs.statSync(job.dstPath);
+    if (size === 0) {
+      throw new Error(`Badged icon ${job.dstPath} was written empty`);
+    }
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR fixes the app icon badge build flow by replacing the direct `app-icon-badge` Expo plugin usage with a local plugin that generates badged icons before Expo prebuild consumes them.

## What changed

- Switched `app.config.ts` to use a local `appIconBadge.plugin.js` instead of the package-provided `app-icon-badge` plugin.
- Added a custom app icon badge plugin that:
  - updates the app, iOS, and Android adaptive foreground icon paths to generated badged icon files under `.expo/app-icon-badge`
  - generates those files synchronously during config resolution
  - caches generation based on source icon file metadata to avoid unnecessary regeneration
- Added a `scripts/generate-icon-badges.js` helper script to create the badged icon assets and validate that the output files were written correctly.
- Added a patch for `app-icon-badge` so badge image writes are properly awaited before returning.

## Functional impact

This change prevents build/prebuild failures on clean environments such as EAS where Expo may try to read generated badged icon files before they exist or before they are fully written. It ensures the required icon assets are ready and non-empty before Expo continues processing them.
<!-- kody-pr-summary:end -->