### PR TITLE
BB-T43 Style fix

### DIFF
--- a/src/components/ui/icon/index.tsx
+++ b/src/components/ui/icon/index.tsx
@@ -31,12 +31,15 @@ const iconStyle = tva({
 const StyledUIIcon = styled(UIIcon, {
   className: {
     target: 'style',
+    // Values must be prop paths, never `true`: react-native-css resolves each one with
+    // `path.split('.')`, so a boolean throws "undefined is not a function" the moment the class
+    // actually produces that style key — which for the size variants is every render.
     nativeStyleMapping: {
-      height: true,
-      width: true,
-      fill: true,
+      height: 'height',
+      width: 'width',
+      fill: 'fill',
       color: 'classNameColor',
-      stroke: true,
+      stroke: 'stroke',
     },
   },
 });

--- a/src/components/ui/spinner/index.tsx
+++ b/src/components/ui/spinner/index.tsx
@@ -5,7 +5,9 @@ import React from 'react';
 import { ActivityIndicator } from 'react-native';
 
 const StyledActivityIndicator = styled(ActivityIndicator, {
-  className: { target: 'style', nativeStyleMapping: { color: true } },
+  // A prop path, not `true`: react-native-css calls `.split('.')` on the value, so a boolean
+  // crashes as soon as the className resolves to a colour.
+  className: { target: 'style', nativeStyleMapping: { color: 'color' } },
 });
 
 const spinnerStyle = tva({});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary
Fixes styling-related crashes in the shared `Icon` and `Spinner` UI components by correcting how class-based native style properties are mapped.

## What changed
- Updated the `Icon` component’s native style mappings for:
  - `height`
  - `width`
  - `fill`
  - `stroke`
- Updated the `Spinner` component’s native style mapping for:
  - `color`

## Functional impact
- Prevents runtime errors when these components receive class-based styles for size, color, fill, or stroke.
- Restores expected styling behavior for icons and spinners in React Native.
- Improves reliability of shared UI primitives used across the app.

## Why
The previous style mappings used boolean values where the styling system expects prop-path strings. This caused crashes when affected style classes were resolved.
<!-- kody-pr-summary:end -->